### PR TITLE
feature: Added `PostBox` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "axum 0.7.4",
  "clap",
  "futures",
+ "fxhash",
  "local-ip-address",
  "prost",
  "rand",
@@ -476,6 +477,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ example = ["local-ip-address"]
 [dependencies]
 axum = "0.7.4"
 clap = { version = "4.5.3", features = ["derive"] }
+fxhash = "0.2.1"
 local-ip-address = { version = "0.6.1", optional = true }
 prost = "0.12"
 rand = "0.8.5"

--- a/proto/ants.proto
+++ b/proto/ants.proto
@@ -8,6 +8,7 @@ service WorkerAnt {
   rpc Reserve (Empty) returns (ReserveReply) {}
   rpc Release (ReleaseRequest) returns (ReleaseReply) {}
   rpc Work (WorkRequest) returns (WorkReply) {}
+  rpc Deliver (DeliverRequest) returns (DeliverReply) {}
 }
 
 
@@ -45,11 +46,28 @@ message WorkRequest {
   uint32 port = 4;
 }
 
-// A reply for completion of work.
+// A reply to indicate if the work request was accepted.
 message WorkReply {
   uint64 token = 1;
-  bool success = 2;
-  string error = 3;
-  string body = 4;
+  uint64 task_id = 2;
+  bool success = 3;
+  string message = 4;
   string worker = 5;
+}
+
+// A reply for completion of work.
+message DeliverRequest {
+  uint64 token = 1;
+  uint64 task_id = 2;
+  bool success = 3;
+  string error = 4;
+  string body = 5;
+  string worker = 6;
+}
+
+// A reply for acknowledging the delivery.
+message DeliverReply {
+  uint64 token = 1;
+  uint64 task_id = 2;
+  bool success = 3;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,4 +37,16 @@ pub enum AntsError {
     InvalidWorkResult(String),
     #[error("Remote worker is not available at http://{0}:{1}: {2}")]
     ConnectionError(String, u16, String),
+
+    // Postbox
+    #[error("Message #{0} not found, cannot be used.")]
+    MessageNotFound(String),
+    #[error("Message #{0} already set; cannot set again.")]
+    MessageAlreadySet(String),
+    #[error("Message #{0} not set.")]
+    MessageNotSet(String),
+    #[error("Incompatible message found: expected {0}, got {1}")]
+    IncompatibleMessage(String, String),
+    #[error("Incompatible receipient type used for MessageType::{0}: {1}")]
+    IncompatibleRecipientType(String, String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@ pub use config::CliArgs;
 #[cfg(feature = "example")]
 pub mod example;
 
+pub mod postbox;
+
+pub mod token;
+
 mod worker;
 pub use worker::*;
 

--- a/src/postbox/message/mod.rs
+++ b/src/postbox/message/mod.rs
@@ -1,0 +1,15 @@
+//! A
+
+mod types;
+pub use types::*;
+
+mod model;
+pub use model::*;
+
+mod set;
+pub use set::*;
+
+mod wrapper;
+pub use wrapper::*;
+
+pub mod traits;

--- a/src/postbox/message/model.rs
+++ b/src/postbox/message/model.rs
@@ -1,0 +1,98 @@
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Notify;
+
+use crate::errors::AntsError;
+
+use super::{traits, MessageBody, MessageId};
+
+/// A message that can be awaited for.
+#[derive(Debug)]
+pub struct Message<T: traits::MessageBodyTypeMarker> {
+    identifier: MessageId,
+    notify: Arc<Notify>,
+    body: OnceLock<MessageBody<T>>,
+}
+
+impl<T: traits::MessageBodyTypeMarker> std::hash::Hash for Message<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.identifier.hash(state);
+    }
+}
+
+impl<T: traits::MessageBodyTypeMarker> std::cmp::PartialEq for Message<T> {
+    /// Compare two messages by their identifier, and that their notifier is the
+    /// same instance.
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier == other.identifier && Arc::ptr_eq(&self.notify, &other.notify)
+    }
+}
+
+impl<T: traits::MessageBodyTypeMarker> Message<T> {
+    /// Create a new message with the given identifier.
+    pub fn new(identifier: MessageId) -> Self {
+        Self {
+            identifier,
+            notify: Arc::new(Notify::new()),
+            body: OnceLock::new(),
+        }
+    }
+
+    /// Get the identifier of the message.
+    pub fn identifier(&self) -> MessageId {
+        self.identifier
+    }
+
+    /// Get the underlying notifier for this message.
+    pub fn notify(&self) -> Arc<Notify> {
+        self.notify.clone()
+    }
+
+    /// Get the timestamp of the message body, if it has been set.
+    pub fn timestamp(&self) -> Option<tokio::time::Instant> {
+        self.body.get().map(|body| body.timestamp)
+    }
+
+    /// Get the age of the message body, if it has been set.
+    pub fn age(&self) -> Option<tokio::time::Duration> {
+        self.timestamp().map(|ts| ts.elapsed())
+    }
+
+    /// Wait for the message to be resolved with a timeout.
+    pub async fn wait_for(&self, timeout: tokio::time::Duration) -> Result<&T, AntsError> {
+        tokio::select! {
+            _ = self.notify.notified() => {
+                self.body.get().map(|b| &b.payload).ok_or(
+                    AntsError::MessageNotSet(format!("{:?}", self.identifier))
+                )
+            }
+            _ = tokio::time::sleep(timeout) => {
+                Err(AntsError::TaskExecutionError(
+                    format!("Timed out waiting for message {0:?}.", self.identifier)
+                ))
+            }
+        }
+    }
+}
+
+impl<T> traits::HandleMessageBody<T> for Message<T>
+where
+    T: traits::MessageBodyTypeMarker,
+{
+    /// Get the body of the message.
+    fn get_body(&self) -> Result<&T, AntsError> {
+        self.body
+            .get()
+            .map(|b| &b.payload)
+            .ok_or(AntsError::MessageNotSet(format!("{:?}", self.identifier)))
+    }
+
+    /// Set the body of the message.
+    async fn set_body(&self, body: T) -> Result<(), AntsError> {
+        self.body
+            .set(MessageBody::new(body))
+            .map_err(|_| AntsError::MessageAlreadySet(format!("{:?}", self.identifier)))?;
+        self.notify.notify_waiters();
+
+        Ok(())
+    }
+}

--- a/src/postbox/message/set.rs
+++ b/src/postbox/message/set.rs
@@ -1,0 +1,12 @@
+//! The type alias for a [`fxhash::HashSet`] of [`MessageType`]s.
+//!
+//!
+use super::{MessageId, MessageType};
+use fxhash::FxHashMap;
+use std::sync::Arc;
+
+/// The unique key for a message. This is used for the [`fxhash::FxHashMap`] to deduplicate messages.
+pub type MessageKey = (&'static str, MessageId);
+
+/// The type alias for a [`fxhash::FxHashMap`] of [`MessageType`]s.
+pub type MessageMap = FxHashMap<MessageKey, Arc<MessageType>>;

--- a/src/postbox/message/traits.rs
+++ b/src/postbox/message/traits.rs
@@ -1,0 +1,57 @@
+//! Common traits for [`Message`]s.
+//!
+
+use crate::{worker::proto::*, AntsError};
+
+use super::{Message, MessageId, MessageKey, MessageType};
+
+/// A marker trait for any types that can be used as a message body.
+pub trait MessageBodyTypeMarker: std::fmt::Debug {
+    /// Create a new message with the given key.
+    fn create_message(key: MessageId) -> MessageType;
+}
+
+macro_rules! expand_message_types {
+    (
+        $($variant:ident($mapped_type:ident)),*$(,)?
+    ) => {
+        $(
+            impl MessageBodyTypeMarker for $mapped_type {
+                fn create_message(identifier: MessageId) -> MessageType {
+                    MessageType::$variant(Message::<$mapped_type>::new(identifier))
+                }
+            }
+        )*
+    }
+}
+
+expand_message_types!(
+    Ping(PingReply),
+    Reserve(ReserveReply),
+    Release(ReleaseReply),
+    Work(WorkReply),
+    Deliver(DeliverRequest),
+);
+
+/// A trait allowing generic setting of the message body.
+#[allow(async_fn_in_trait)]
+pub trait HandleMessageBody<T>
+where
+    T: MessageBodyTypeMarker,
+{
+    /// Get the body of the message.
+    fn get_body(&self) -> Result<&T, AntsError>;
+
+    /// Set the body of the message.
+    async fn set_body(&self, body: T) -> Result<(), AntsError>;
+}
+
+/// A trait allowing generic setting of the message body.
+#[allow(async_fn_in_trait)]
+pub trait SetMessageBodyByKey<T>
+where
+    T: MessageBodyTypeMarker,
+{
+    /// Set the body of the message.
+    async fn set_body(&self, key: &MessageKey, body: T) -> Result<(), AntsError>;
+}

--- a/src/postbox/message/types.rs
+++ b/src/postbox/message/types.rs
@@ -1,0 +1,26 @@
+//! Common types for [`Message`]s.
+
+use crate::token::MessageToken;
+
+use crate::worker::token::ReservationToken;
+
+/// The unique identifier for a message. This is used for the [`fxhash::HashSet`] to
+/// deduplicate messages.
+pub type MessageId = (ReservationToken, MessageToken);
+
+/// The body of a message, containing a timestamped payload.
+#[derive(Debug)]
+pub struct MessageBody<T: std::fmt::Debug> {
+    pub payload: T,
+    pub timestamp: tokio::time::Instant,
+}
+
+impl<T: std::fmt::Debug> MessageBody<T> {
+    /// Create a new message body with the given payload.
+    pub fn new(payload: T) -> Self {
+        Self {
+            payload,
+            timestamp: tokio::time::Instant::now(),
+        }
+    }
+}

--- a/src/postbox/message/wrapper.rs
+++ b/src/postbox/message/wrapper.rs
@@ -1,0 +1,182 @@
+//! An enum wrapper to provide a uniform type for all messages.
+
+use super::Message;
+
+use std::ops::Deref;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+use super::{traits, MessageKey};
+use crate::{worker::proto::*, AntsError};
+
+use super::super::PostBox;
+
+/// A wrapper for all message types.
+#[derive(Debug, PartialEq)]
+pub enum MessageType {
+    /// A ping message, which contains no reply.
+    Ping(Message<PingReply>),
+
+    /// A Reserve message, which contains the reservation result.
+    Reserve(Message<ReserveReply>),
+
+    /// A Release message, which contains the release result.
+    Release(Message<ReleaseReply>),
+
+    /// A work message, which contains the work acknowledgement.
+    Work(Message<WorkReply>),
+
+    /// A delivery message, which contains the work result.
+    ///
+    /// This is a special message that is triggered by the remote worker, hence
+    /// it is stored as the request, not the reply.
+    Deliver(Message<DeliverRequest>),
+}
+
+impl std::cmp::Eq for MessageType {}
+
+impl std::hash::Hash for MessageType {
+    /// Hash the message, including its type and the message body.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        macro_rules! expand_variants {
+            ($($variant:ident),*) => {
+                match self {
+                    $(Self::$variant(msg) => {
+                        stringify!($variant).hash(state);
+                        msg.hash(state)
+                    },)*
+                }
+            }
+        }
+
+        expand_variants!(Ping, Reserve, Release, Work, Deliver);
+    }
+}
+
+macro_rules! expand_variants {
+    ($($variant:ident),*) => {
+        impl MessageType {
+            /// Get the name of the kind of message.
+            pub const fn kind(&self) -> &'static str {
+                match self {
+                    $(Self::$variant(_) => stringify!($variant),)*
+                }
+            }
+
+            /// Get the key of the message.
+            pub fn key(&self) -> MessageKey {
+                match self {
+                    $(Self::$variant(msg) => (self.kind(), msg.identifier()),)*
+                }
+            }
+
+            /// Get the internal [`Notify`] instance for the message.
+            pub fn notify(&self) -> Arc<Notify> {
+                match self {
+                    $(Self::$variant(msg) => msg.notify(),)*
+                }
+            }
+
+            /// Wait for the message to be populated, with a defined timeout.
+            ///
+            /// Contrary to the [`Message::wait_for`] method that this wraps, this
+            /// method returns [`()`] instead of the message body.
+            pub async fn wait_for(&self, timeout: tokio::time::Duration) -> Result<(), AntsError> {
+                match self {
+                    $(Self::$variant(msg) => msg.wait_for(timeout).await.map(|_| ()),)*
+                }
+            }
+
+            /// Get the timestamp of the message, if it has been set.
+            pub fn timestamp(&self) -> Option<tokio::time::Instant> {
+                match self {
+                    $(Self::$variant(msg) => msg.timestamp(),)*
+                }
+            }
+
+            /// Get the age of the message, if it has been set.
+            pub fn age(&self) -> Option<tokio::time::Duration> {
+                match self {
+                    $(Self::$variant(msg) => msg.age(),)*
+                }
+            }
+        }
+
+    }
+}
+
+expand_variants!(Ping, Reserve, Release, Work, Deliver);
+
+macro_rules! expand_from_types {
+    (
+        $($variant:ident($mapped_type:ident)),*$(,)?
+    ) => {
+        $(
+            impl From<Message<$mapped_type>> for MessageType {
+                fn from(msg: Message<$mapped_type>) -> Self {
+                    Self::$variant(msg)
+                }
+            }
+        )*
+
+        $(
+            impl traits::HandleMessageBody<$mapped_type> for MessageType {
+                /// Get the body of the message.
+                fn get_body(&self) -> Result<&$mapped_type, AntsError> {
+                    match self {
+                        Self::$variant(msg) => msg.get_body(),
+                        _ => Err(AntsError::IncompatibleRecipientType(
+                            self.kind().to_owned(),
+                            stringify!($mapped_type).to_owned(),
+                        )),
+                    }
+                }
+
+                /// Set the body of the message.
+                async fn set_body(&self, body: $mapped_type) -> Result<(), AntsError> {
+                    match self {
+                        Self::$variant(msg) => msg.set_body(body).await,
+                        _ => Err(AntsError::IncompatibleMessage(
+                            stringify!($mapped_type).to_owned(),
+                            std::any::type_name_of_val(&body).to_owned(),
+                        )),
+                    }
+                }
+            }
+
+            /// Implement the same for [`PostBox`].
+            impl traits::SetMessageBodyByKey<$mapped_type> for PostBox {
+                /// Set the body of the message.
+                async fn set_body(&self, key: &MessageKey, body: $mapped_type) -> Result<(), AntsError> {
+                    let message = self.get(key).await?;
+
+                    // Call the inner implementation to do the actual setting.
+                    traits::HandleMessageBody::<$mapped_type>::set_body(message.deref(), body).await
+                }
+            }
+
+            impl TryFrom<MessageType> for Message<$mapped_type> {
+                type Error = AntsError;
+
+                /// Attempt to convert the message type into the inner message.
+                fn try_from(msg: MessageType) -> Result<Self, Self::Error> {
+                    match msg {
+                        MessageType::$variant(msg) => Ok(msg),
+                        _ => Err(AntsError::IncompatibleMessage(
+                            std::any::type_name_of_val(&msg).to_owned(),
+                            stringify!($variant).to_owned(),
+                        )),
+                    }
+                }
+            }
+        )*
+    }
+}
+
+expand_from_types! {
+    Ping(PingReply),
+    Reserve(ReserveReply),
+    Release(ReleaseReply),
+    Work(WorkReply),
+    Deliver(DeliverRequest),
+}

--- a/src/postbox/mod.rs
+++ b/src/postbox/mod.rs
@@ -1,0 +1,13 @@
+//! A postbox is a staging area where messages are stored before they are being delivered
+//! to the recipient. Assume process A wants to send a message to process B, and expects
+//! a reply in response. Since the messages are delivered asynchronously, process A needs
+//! to await the reply without keeping the connection open. The postbox shall be the one
+//! listening for any replies, perform any necessary processing and deduplications, then
+//! notify anyone who is waiting for the reply.
+//!
+
+mod message;
+pub use message::*;
+
+mod model;
+pub use model::*;

--- a/src/postbox/model.rs
+++ b/src/postbox/model.rs
@@ -1,0 +1,181 @@
+//! The postbox module that handles the receipt of foreign messages and their subsequent
+//! delivery locally.
+//!
+//!
+use crate::AntsError;
+
+use super::message::{
+    traits::MessageBodyTypeMarker, MessageId, MessageKey, MessageMap, MessageType,
+};
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+/// The postbox that receives messages and delivers them to the recipient.
+pub struct PostBox {
+    messages: RwLock<MessageMap>,
+}
+
+/// NOTE Part of implementation is in `wrapper.rs`, allowing setting the message
+/// body by key.
+impl Default for PostBox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PostBox {
+    /// Create a new postbox.
+    pub fn new() -> Self {
+        Self {
+            messages: RwLock::new(MessageMap::default()),
+        }
+    }
+
+    /// Create a new postbox, and return the atomic reference to it.
+    pub fn new_arc() -> Arc<Self> {
+        Arc::new(Self::new())
+    }
+
+    /// Create a new message of the given type.
+    pub async fn create_message<T>(&self, identifier: MessageId) -> Arc<MessageType>
+    where
+        T: MessageBodyTypeMarker,
+    {
+        self.insert(T::create_message(identifier)).await
+    }
+
+    /// Add a [`MessageType`] to the postbox, and return the atomic reference to it.
+    pub async fn insert(&self, message: MessageType) -> Arc<MessageType> {
+        let mut messages = self.messages.write().await;
+        let message_ref = Arc::new(message);
+        messages.insert(message_ref.key(), message_ref.clone());
+
+        message_ref
+    }
+
+    /// Get the atomic reference to a [`MessageType`] from the postbox by its key.
+    ///
+    /// If the message is not found, this will return [G`None`].
+    pub async fn get(&self, key: &MessageKey) -> Result<Arc<MessageType>, AntsError> {
+        let messages = self.messages.read().await;
+        messages
+            .get(key)
+            .cloned()
+            .ok_or_else(|| AntsError::MessageNotFound(format!("{:?}", key)))
+    }
+
+    /// Remove a [`MessageType`] from the postbox by its key.
+    pub async fn remove(&self, key: &MessageKey) -> Option<Arc<MessageType>> {
+        let mut messages = self.messages.write().await;
+        messages.remove(key)
+    }
+
+    /// Get the number of messages in the postbox.
+    pub async fn len(&self) -> usize {
+        let messages = self.messages.read().await;
+        messages.len()
+    }
+
+    /// Check if the postbox is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.len().await == 0
+    }
+
+    /// Remove all messages that have been delivered older than the given duration.
+    pub async fn clean_old_messages(&self, duration: tokio::time::Duration) {
+        let mut messages = self.messages.write().await;
+        messages.retain(|_, message| {
+            message
+                .age()
+                .map(|age| age < duration)
+                .unwrap_or_else(|| true)
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        postbox::{
+            traits::{HandleMessageBody, SetMessageBodyByKey},
+            Message,
+        },
+        token::generate_token as generate_message_token,
+        worker::{proto::*, token::generate_token as generate_reservation_token},
+    };
+
+    #[tokio::test]
+    async fn simple() {
+        let postbox = PostBox::new_arc();
+
+        let token = generate_reservation_token();
+        let task_id = generate_message_token();
+
+        let identifier = (token, task_id);
+
+        let message = postbox.create_message::<DeliverRequest>(identifier).await;
+        let key = message.key();
+
+        let body = "Test Body";
+
+        let remote_task = {
+            let remote_postbox = postbox.clone();
+
+            let expected = DeliverRequest {
+                token,
+                task_id,
+                success: true,
+                error: String::default(),
+                body: body.to_owned(),
+                worker: "Test Worker".to_owned(),
+            };
+
+            let mut bad_result = expected.clone();
+            bad_result.body = "Bad Body".to_owned();
+
+            // This is to simulate the remote worker sending a message to the postbox.
+            async move {
+                eprintln!("Sleeping for a bit.");
+                tokio::time::sleep(tokio::time::Duration::from_secs_f32(0.5)).await;
+
+                eprintln!("Setting the message body.");
+                remote_postbox
+                    .set_body(&key, expected)
+                    .await
+                    .expect("Failed to set the message body.");
+
+                eprintln!("Setting the message body again, expecting a failure.");
+                let result = remote_postbox.set_body(&key, bad_result).await;
+                assert!(result.is_err());
+            }
+        };
+        let local_task = async move {
+            eprintln!("Waiting for the message.");
+            message
+                .wait_for(tokio::time::Duration::from_secs(1))
+                .await
+                .unwrap();
+            eprintln!("Message received.")
+        };
+
+        tokio::join!(remote_task, local_task);
+
+        let message = Arc::try_unwrap(
+            postbox
+                .remove(&key)
+                .await
+                .expect("Failed to remove the message."),
+        )
+        .expect("Failed to unwrap the Arc: the message is still in use elsewhere.");
+
+        let inner: Message<DeliverRequest> = message
+            .try_into()
+            .expect("Failed to convert the message into the inner type.");
+
+        let delivered = inner.get_body().expect("Failed to get the message body.");
+
+        assert_eq!(&delivered.body, body);
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,12 @@
+//! Generation of message tokens for workers.
+//!
+
+use rand::Rng;
+
+/// A reservation token.
+pub type MessageToken = u64;
+
+/// Generate a random message token.
+pub fn generate_token() -> u64 {
+    rand::thread_rng().gen_range(1..u64::MAX)
+}

--- a/src/worker/token.rs
+++ b/src/worker/token.rs
@@ -1,15 +1,13 @@
 //! Generation of reservation tokens for workers.
 //!
 
-use rand::Rng;
+use crate::token;
+
+/// Re-export the token generation function as reservation token generator.
+pub use token::generate_token;
 
 /// A reservation token.
-pub type ReservationToken = u64;
+pub type ReservationToken = token::MessageToken;
 
 /// Timeout for a token.
 pub const TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(15);
-
-/// Generate a random reservation token.
-pub fn generate_token() -> u64 {
-    rand::thread_rng().gen_range(1..u64::MAX)
-}

--- a/tests/multi_nodes.rs
+++ b/tests/multi_nodes.rs
@@ -83,6 +83,11 @@ async fn test_multi_nodes(worker_count: usize) {
         })
         .collect::<std::collections::HashSet<_>>();
 
+    eprintln!(
+        "Commissioned workers: {:?}",
+        commissioned_workers.iter().collect::<Vec<_>>()
+    );
+
     // Make sure all workers were used.
     assert_eq!(commissioned_workers.len(), worker_count);
 }


### PR DESCRIPTION
Added `PostBox` as part of a link abstraction on top of `Worker`. This moves the `work` call to be asynchronous in nature - the remote worker will send a reply first confirming the job had been received; upon completion of task, the remote worker will then open a different connection back to the host to deliver the work result.

This allows all result waiting to be unified in one listening port, and permits further link abstractions such as message deduplication etc, which `PostBox` already supports.